### PR TITLE
Indicate that there was no error rec'd

### DIFF
--- a/views/pages/main.ejs
+++ b/views/pages/main.ejs
@@ -22,7 +22,11 @@ overflow-wrap: break-word;
 <p><%= refresh_token %></p>
 
 <h3>Error</h3>
-<p><%= error_str %></p>
+<% if(error_str) { %>
+    <p><%= error_str %></p>
+<% } else { %>
+    <p>(no error!)</p>
+<% } %>
 
 </body>
 


### PR DESCRIPTION
Super minor update, wanted to propose this change to the sample page - when I first got all the plumbing up I had some issues using the token - double checking the oauth side, thought the Error header was actually telling me there was a problem in the token request and was debugging that, but instead it was my request _using_ the token that was malformed^. This text would've clued me in that it wasn't the oauth flow and was me...


^ I somehow had in the header in Authori`s`ation instead of Authori`z`ation.